### PR TITLE
Fix gofmt and add support of recursive path format to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,6 @@ before_script:
   - gometalinter --install
  
 script:
-  - diff -u <(echo -n) <(gofmt -d -s $(go list ./... | grep -v /vendor/))
-  - gometalinter ./...
-  - go test ./...
+  - diff <(echo -n) <(gofmt -l $(find -name "*.go" | grep -v /vendor))
+  - gometalinter ./... --vendor --deadline 100s
+  - go test ./... -v


### PR DESCRIPTION
Fix gofmt to check go format,
add support of recursive path format, ignore vendor directory and set deadline,
add more info to go test.