### PR TITLE
Add structures to error handling

### DIFF
--- a/blueprint/Blueprint.go
+++ b/blueprint/Blueprint.go
@@ -2,7 +2,8 @@ package blueprint
 
 import (
 	"bytes"
-	"fmt"
+
+	"github.com/onego-project/onego/errors"
 
 	"github.com/beevik/etree"
 )
@@ -28,7 +29,7 @@ func CreateBlueprint(rootElement string) *Blueprint {
 // Render method to render blueprint values to string
 func (bp *Blueprint) Render() (string, error) {
 	if bp.XMLData == nil {
-		return "", fmt.Errorf("blueprint XML data is empty")
+		return "", errors.ErrBlueprintXMLEmpty
 	}
 
 	var buffer bytes.Buffer

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -1,0 +1,60 @@
+package errors
+
+import (
+	"errors"
+	"fmt"
+)
+
+// OpenNebulaError structure represents errors caused by OpenNebula
+type OpenNebulaError struct {
+	Code     int
+	Message  string
+	ObjectID int
+}
+
+// XMLElementError structure represents errors in XML elements
+type XMLElementError struct {
+	Path string
+}
+
+// ErrNoClient error
+var ErrNoClient = errors.New("no client")
+
+// ErrNoImage error
+var ErrNoImage = errors.New("no image to finish test")
+
+// ErrNoImageBlueprint error
+var ErrNoImageBlueprint = errors.New("no image blueprint to finish test")
+
+// ErrNoGroup error
+var ErrNoGroup = errors.New("no group to finish test")
+
+// ErrNoDatastore error
+var ErrNoDatastore = errors.New("no datastore to finish test")
+
+// ErrNoDatastoreBlueprint error
+var ErrNoDatastoreBlueprint = errors.New("no datastore blueprint to finish test")
+
+// ErrNoUser error
+var ErrNoUser = errors.New("no user to finish test")
+
+// ErrNoUserBlueprint error
+var ErrNoUserBlueprint = errors.New("no user blueprint to finish test")
+
+// ErrBlueprintXMLEmpty error
+var ErrBlueprintXMLEmpty = errors.New("blueprint XML data is empty")
+
+// NoObjectID to distinguish errors from OpenNebula with 3 or 4 arguments
+var NoObjectID = -1
+
+func (one *OpenNebulaError) Error() string {
+	if one.ObjectID != NoObjectID {
+		return fmt.Sprintf("%s, error code: %d, id of the object "+
+			"that caused the error %d", one.Message, one.Code, one.ObjectID)
+	}
+	return fmt.Sprintf("%s, error code: %d", one.Message, one.Code)
+}
+
+func (xee *XMLElementError) Error() string {
+	return fmt.Sprintf("no element %s", xee.Path)
+}

--- a/resources/Image.go
+++ b/resources/Image.go
@@ -1,8 +1,9 @@
 package resources
 
 import (
-	"fmt"
 	"time"
+
+	"github.com/onego-project/onego/errors"
 
 	"github.com/beevik/etree"
 )
@@ -226,7 +227,7 @@ func (i *Image) Snapshots() ([]*ImageSnapshot, error) {
 
 func createImageSnapshotFromElement(element *etree.Element) (*ImageSnapshot, error) {
 	if element == nil {
-		return nil, fmt.Errorf("empty snapshot element")
+		return nil, &errors.XMLElementError{Path: "snapshot"}
 	}
 
 	// occurrence 0 - 1 (we can ignore error)

--- a/resources/Resource.go
+++ b/resources/Resource.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"github.com/beevik/etree"
+	"github.com/onego-project/onego/errors"
 )
 
 // Resource structure contains XML data and main methods for open nebula resources
@@ -53,12 +54,12 @@ func (r *Resource) intAttribute(path string) (int, error) {
 
 func attributeFromElement(e *etree.Element, path string) (string, error) {
 	if e == nil {
-		return "", fmt.Errorf("no element, unable to get %s", path)
+		return "", &errors.XMLElementError{Path: path}
 	}
 
 	element := e.FindElement(path)
 	if element == nil {
-		return "", fmt.Errorf("unable to find %s", path)
+		return "", &errors.XMLElementError{Path: path}
 	}
 	return element.Text(), nil
 }

--- a/resources/User.go
+++ b/resources/User.go
@@ -1,11 +1,11 @@
 package resources
 
 import (
-	"fmt"
 	"strconv"
 	"time"
 
 	"github.com/beevik/etree"
+	"github.com/onego-project/onego/errors"
 )
 
 // User structure represents user and inherits XML data and methods from Resource structure
@@ -53,7 +53,7 @@ func (u *User) Groups() ([]int, error) {
 	}
 
 	if len(groups) < 1 { // should never happen that user has no group
-		return nil, fmt.Errorf("no group")
+		return nil, &errors.XMLElementError{Path: "group"}
 	}
 
 	return groups, nil
@@ -80,12 +80,12 @@ func (u *User) LoginTokens() ([]LoginToken, error) {
 	for i, e := range elements {
 		tokenElement := e.FindElement("TOKEN")
 		if tokenElement == nil {
-			return nil, fmt.Errorf("no token in login token")
+			return nil, &errors.XMLElementError{Path: "token in login token"}
 		}
 
 		expTimeElement := e.FindElement("EXPIRATION_TIME")
 		if expTimeElement == nil {
-			return nil, fmt.Errorf("no expiration time in login token")
+			return nil, &errors.XMLElementError{Path: "expiration time in login token"}
 		}
 
 		expTime, err := strconv.ParseInt(expTimeElement.Text(), base10, bitSize64)
@@ -103,7 +103,7 @@ func (u *User) LoginTokens() ([]LoginToken, error) {
 
 		egidElement := e.FindElement("EGID")
 		if egidElement == nil {
-			return nil, fmt.Errorf("no egid in login token")
+			return nil, &errors.XMLElementError{Path: "egid in login token"}
 		}
 
 		egid, err := strconv.Atoi(egidElement.Text())

--- a/services/DatastoreService_test.go
+++ b/services/DatastoreService_test.go
@@ -3,9 +3,10 @@ package services_test
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io/ioutil"
 	"net/http"
+
+	"github.com/onego-project/onego/errors"
 
 	"github.com/dnaeon/go-vcr/cassette"
 	"github.com/dnaeon/go-vcr/recorder"
@@ -92,7 +93,7 @@ var _ = ginkgo.Describe("Datastore Service", func() {
 		// create onego client
 		client = onego.CreateClient(endpoint, token, clientHTTP)
 		if client == nil {
-			err = fmt.Errorf("no client")
+			err = errors.ErrNoClient
 			return
 		}
 	})
@@ -187,7 +188,7 @@ var _ = ginkgo.Describe("Datastore Service", func() {
 
 				datastore = resources.CreateDatastoreWithID(105)
 				if datastore == nil {
-					err = fmt.Errorf("no datastore to finish test")
+					err = errors.ErrNoDatastore
 				}
 			})
 
@@ -213,7 +214,7 @@ var _ = ginkgo.Describe("Datastore Service", func() {
 
 				datastore = resources.CreateDatastoreWithID(110)
 				if datastore == nil {
-					err = fmt.Errorf("no datastore to finish test")
+					err = errors.ErrNoDatastore
 				}
 			})
 
@@ -254,7 +255,7 @@ var _ = ginkgo.Describe("Datastore Service", func() {
 				ginkgo.BeforeEach(func() {
 					datastore = resources.CreateDatastoreWithID(104)
 					if datastore == nil {
-						err = fmt.Errorf("no datastore to finish test")
+						err = errors.ErrNoDatastore
 						return
 					}
 				})
@@ -269,7 +270,7 @@ var _ = ginkgo.Describe("Datastore Service", func() {
 
 						datastoreBlueprint = blueprint.CreateUpdateDatastoreBlueprint()
 						if datastoreBlueprint == nil {
-							err = fmt.Errorf("no datastore blueprint to finish test")
+							err = errors.ErrNoDatastoreBlueprint
 							gomega.Expect(err).NotTo(gomega.HaveOccurred())
 						}
 						datastoreBlueprint.SetDsMad("dummy")
@@ -298,7 +299,7 @@ var _ = ginkgo.Describe("Datastore Service", func() {
 
 						datastoreBlueprint = blueprint.CreateUpdateDatastoreBlueprint()
 						if datastoreBlueprint == nil {
-							err = fmt.Errorf("no datastore blueprint to finish test")
+							err = errors.ErrNoDatastoreBlueprint
 							gomega.Expect(err).NotTo(gomega.HaveOccurred())
 						}
 						datastoreBlueprint.SetType(resources.DatastoreTypeSystem)
@@ -322,7 +323,7 @@ var _ = ginkgo.Describe("Datastore Service", func() {
 				ginkgo.BeforeEach(func() {
 					datastore = resources.CreateDatastoreWithID(104)
 					if datastore == nil {
-						err = fmt.Errorf("no datastore to finish test")
+						err = errors.ErrNoDatastore
 						return
 					}
 
@@ -363,12 +364,12 @@ var _ = ginkgo.Describe("Datastore Service", func() {
 
 				datastore = resources.CreateDatastoreWithID(110)
 				if datastore == nil {
-					err = fmt.Errorf("no datastore to finish test")
+					err = errors.ErrNoDatastore
 				}
 
 				datastoreBlueprint = blueprint.CreateUpdateDatastoreBlueprint()
 				if datastoreBlueprint == nil {
-					err = fmt.Errorf("no datastore blueprint to finish test")
+					err = errors.ErrNoDatastoreBlueprint
 					return
 				}
 				datastoreBlueprint.SetType(resources.DatastoreTypeSystem)
@@ -388,7 +389,7 @@ var _ = ginkgo.Describe("Datastore Service", func() {
 
 				datastoreBlueprint = blueprint.CreateUpdateDatastoreBlueprint()
 				if datastoreBlueprint == nil {
-					err = fmt.Errorf("no datastore blueprint to finish test")
+					err = errors.ErrNoDatastoreBlueprint
 					return
 				}
 				datastoreBlueprint.SetType(resources.DatastoreTypeSystem)
@@ -415,7 +416,7 @@ var _ = ginkgo.Describe("Datastore Service", func() {
 			ginkgo.BeforeEach(func() {
 				datastore = resources.CreateDatastoreWithID(106)
 				if datastore == nil {
-					err = fmt.Errorf("no datastore to finish test")
+					err = errors.ErrNoDatastore
 				}
 			})
 
@@ -470,7 +471,7 @@ var _ = ginkgo.Describe("Datastore Service", func() {
 
 				datastore = resources.CreateDatastoreWithID(110)
 				if datastore == nil {
-					err = fmt.Errorf("no datastore to finish test")
+					err = errors.ErrNoDatastore
 				}
 			})
 
@@ -513,7 +514,7 @@ var _ = ginkgo.Describe("Datastore Service", func() {
 			ginkgo.BeforeEach(func() {
 				datastore = resources.CreateDatastoreWithID(106)
 				if datastore == nil {
-					err = fmt.Errorf("no datastore to finish test")
+					err = errors.ErrNoDatastore
 				}
 			})
 
@@ -567,7 +568,7 @@ var _ = ginkgo.Describe("Datastore Service", func() {
 
 				datastore = resources.CreateDatastoreWithID(110)
 				if datastore == nil {
-					err = fmt.Errorf("no datastore to finish test")
+					err = errors.ErrNoDatastore
 				}
 			})
 
@@ -614,7 +615,7 @@ var _ = ginkgo.Describe("Datastore Service", func() {
 			ginkgo.BeforeEach(func() {
 				datastore = resources.CreateDatastoreWithID(106)
 				if datastore == nil {
-					err = fmt.Errorf("no datastore to finish test")
+					err = errors.ErrNoDatastore
 				}
 			})
 
@@ -661,7 +662,7 @@ var _ = ginkgo.Describe("Datastore Service", func() {
 
 				datastore = resources.CreateDatastoreWithID(110)
 				if datastore == nil {
-					err = fmt.Errorf("no datastore to finish test")
+					err = errors.ErrNoDatastore
 				}
 			})
 
@@ -698,7 +699,7 @@ var _ = ginkgo.Describe("Datastore Service", func() {
 			ginkgo.BeforeEach(func() {
 				datastore = resources.CreateDatastoreWithID(106)
 				if datastore == nil {
-					err = fmt.Errorf("no datastore to finish test")
+					err = errors.ErrNoDatastore
 				}
 			})
 
@@ -755,7 +756,7 @@ var _ = ginkgo.Describe("Datastore Service", func() {
 
 				datastore = resources.CreateDatastoreWithID(110)
 				if datastore == nil {
-					err = fmt.Errorf("no datastore to finish test")
+					err = errors.ErrNoDatastore
 				}
 			})
 

--- a/services/GroupService.go
+++ b/services/GroupService.go
@@ -2,9 +2,9 @@ package services
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/onego-project/onego/blueprint"
+	"github.com/onego-project/onego/errors"
 	"github.com/onego-project/onego/resources"
 )
 
@@ -70,7 +70,7 @@ func (gs *GroupService) List(ctx context.Context) ([]*resources.Group, error) {
 
 	elements := doc.FindElements("GROUP_POOL/GROUP")
 	if len(elements) == 0 {
-		return nil, fmt.Errorf("no group in group pool")
+		return nil, &errors.XMLElementError{Path: "group in group pool"}
 	}
 
 	groups := make([]*resources.Group, len(elements))

--- a/services/GroupService_test.go
+++ b/services/GroupService_test.go
@@ -2,8 +2,9 @@ package services_test
 
 import (
 	"context"
-	"fmt"
 	"net/http"
+
+	"github.com/onego-project/onego/errors"
 
 	"github.com/dnaeon/go-vcr/recorder"
 	"github.com/onego-project/onego"
@@ -74,7 +75,7 @@ var _ = ginkgo.Describe("Group", func() {
 		// create onego client
 		client = onego.CreateClient(endpoint, token, clientHTTP)
 		if client == nil {
-			err = fmt.Errorf("no client")
+			err = errors.ErrNoClient
 			return
 		}
 	})

--- a/services/ImageService_test.go
+++ b/services/ImageService_test.go
@@ -3,9 +3,10 @@ package services_test
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io/ioutil"
 	"net/http"
+
+	"github.com/onego-project/onego/errors"
 
 	"github.com/onego-project/onego/requests"
 	"github.com/onego-project/onego/services"
@@ -123,7 +124,7 @@ var _ = ginkgo.Describe("Image Service", func() {
 		// create onego client
 		client = onego.CreateClient(endpoint, token, clientHTTP)
 		if client == nil {
-			err = fmt.Errorf("no client")
+			err = errors.ErrNoClient
 			return
 		}
 	})
@@ -255,7 +256,7 @@ var _ = ginkgo.Describe("Image Service", func() {
 
 					image = resources.CreateImageWithID(378)
 					if image == nil {
-						err = fmt.Errorf("no image to finish test")
+						err = errors.ErrNoImage
 					}
 				})
 
@@ -284,7 +285,7 @@ var _ = ginkgo.Describe("Image Service", func() {
 
 					image = resources.CreateImageWithID(378)
 					if image == nil {
-						err = fmt.Errorf("no image to finish test")
+						err = errors.ErrNoImage
 					}
 				})
 
@@ -344,7 +345,7 @@ var _ = ginkgo.Describe("Image Service", func() {
 
 				image = resources.CreateImageWithID(377)
 				if image == nil {
-					err = fmt.Errorf("no image to finish test")
+					err = errors.ErrNoImage
 				}
 			})
 
@@ -370,7 +371,7 @@ var _ = ginkgo.Describe("Image Service", func() {
 
 				image = resources.CreateImageWithID(110)
 				if image == nil {
-					err = fmt.Errorf("no image to finish test")
+					err = errors.ErrNoImage
 				}
 			})
 
@@ -411,7 +412,7 @@ var _ = ginkgo.Describe("Image Service", func() {
 				ginkgo.BeforeEach(func() {
 					image = resources.CreateImageWithID(378)
 					if image == nil {
-						err = fmt.Errorf("no image to finish test")
+						err = errors.ErrNoImage
 						return
 					}
 				})
@@ -426,7 +427,7 @@ var _ = ginkgo.Describe("Image Service", func() {
 
 						imageBlueprint = blueprint.CreateUpdateImageBlueprint()
 						if imageBlueprint == nil {
-							err = fmt.Errorf("no image blueprint to finish test")
+							err = errors.ErrNoImageBlueprint
 							gomega.Expect(err).NotTo(gomega.HaveOccurred())
 						}
 						imageBlueprint.SetDescription("dummy")
@@ -455,7 +456,7 @@ var _ = ginkgo.Describe("Image Service", func() {
 
 						imageBlueprint = blueprint.CreateUpdateImageBlueprint()
 						if imageBlueprint == nil {
-							err = fmt.Errorf("no image blueprint to finish test")
+							err = errors.ErrNoImageBlueprint
 							gomega.Expect(err).NotTo(gomega.HaveOccurred())
 						}
 						imageBlueprint.SetDiskType(resources.DiskTypeBlock)
@@ -479,7 +480,7 @@ var _ = ginkgo.Describe("Image Service", func() {
 				ginkgo.BeforeEach(func() {
 					image = resources.CreateImageWithID(378)
 					if image == nil {
-						err = fmt.Errorf("no image to finish test")
+						err = errors.ErrNoImage
 						return
 					}
 
@@ -520,12 +521,12 @@ var _ = ginkgo.Describe("Image Service", func() {
 
 				image = resources.CreateImageWithID(110)
 				if image == nil {
-					err = fmt.Errorf("no image to finish test")
+					err = errors.ErrNoImage
 				}
 
 				imageBlueprint = blueprint.CreateUpdateImageBlueprint()
 				if imageBlueprint == nil {
-					err = fmt.Errorf("no image blueprint to finish test")
+					err = errors.ErrNoImageBlueprint
 					return
 				}
 				imageBlueprint.SetDescription("dummy")
@@ -545,7 +546,7 @@ var _ = ginkgo.Describe("Image Service", func() {
 
 				imageBlueprint = blueprint.CreateUpdateImageBlueprint()
 				if imageBlueprint == nil {
-					err = fmt.Errorf("no image blueprint to finish test")
+					err = errors.ErrNoImageBlueprint
 					return
 				}
 				imageBlueprint.SetDescription("dummy")
@@ -574,7 +575,7 @@ var _ = ginkgo.Describe("Image Service", func() {
 
 				image = resources.CreateImageWithID(378)
 				if image == nil {
-					err = fmt.Errorf("no image to finish test")
+					err = errors.ErrNoImage
 				}
 			})
 
@@ -601,7 +602,7 @@ var _ = ginkgo.Describe("Image Service", func() {
 
 				image = resources.CreateImageWithID(110)
 				if image == nil {
-					err = fmt.Errorf("no image to finish test")
+					err = errors.ErrNoImage
 				}
 			})
 
@@ -641,7 +642,7 @@ var _ = ginkgo.Describe("Image Service", func() {
 			ginkgo.BeforeEach(func() {
 				image = resources.CreateImageWithID(378)
 				if image == nil {
-					err = fmt.Errorf("no image to finish test")
+					err = errors.ErrNoImage
 				}
 			})
 
@@ -696,7 +697,7 @@ var _ = ginkgo.Describe("Image Service", func() {
 
 				image = resources.CreateImageWithID(110)
 				if image == nil {
-					err = fmt.Errorf("no image to finish test")
+					err = errors.ErrNoImage
 				}
 			})
 
@@ -742,7 +743,7 @@ var _ = ginkgo.Describe("Image Service", func() {
 			ginkgo.BeforeEach(func() {
 				image = resources.CreateImageWithID(378)
 				if image == nil {
-					err = fmt.Errorf("no image to finish test")
+					err = errors.ErrNoImage
 				}
 			})
 
@@ -796,7 +797,7 @@ var _ = ginkgo.Describe("Image Service", func() {
 
 				image = resources.CreateImageWithID(110)
 				if image == nil {
-					err = fmt.Errorf("no image to finish test")
+					err = errors.ErrNoImage
 				}
 			})
 
@@ -835,7 +836,7 @@ var _ = ginkgo.Describe("Image Service", func() {
 			ginkgo.BeforeEach(func() {
 				image = resources.CreateImageWithID(378)
 				if image == nil {
-					err = fmt.Errorf("no image to finish test")
+					err = errors.ErrNoImage
 				}
 			})
 
@@ -891,7 +892,7 @@ var _ = ginkgo.Describe("Image Service", func() {
 
 				image = resources.CreateImageWithID(110)
 				if image == nil {
-					err = fmt.Errorf("no image to finish test")
+					err = errors.ErrNoImage
 				}
 			})
 
@@ -930,7 +931,7 @@ var _ = ginkgo.Describe("Image Service", func() {
 			ginkgo.BeforeEach(func() {
 				image = resources.CreateImageWithID(378)
 				if image == nil {
-					err = fmt.Errorf("no image to finish test")
+					err = errors.ErrNoImage
 				}
 			})
 
@@ -987,7 +988,7 @@ var _ = ginkgo.Describe("Image Service", func() {
 
 				image = resources.CreateImageWithID(110)
 				if image == nil {
-					err = fmt.Errorf("no image to finish test")
+					err = errors.ErrNoImage
 				}
 			})
 
@@ -1026,7 +1027,7 @@ var _ = ginkgo.Describe("Image Service", func() {
 			ginkgo.BeforeEach(func() {
 				image = resources.CreateImageWithID(378)
 				if image == nil {
-					err = fmt.Errorf("no image to finish test")
+					err = errors.ErrNoImage
 				}
 			})
 
@@ -1083,7 +1084,7 @@ var _ = ginkgo.Describe("Image Service", func() {
 
 				image = resources.CreateImageWithID(110)
 				if image == nil {
-					err = fmt.Errorf("no image to finish test")
+					err = errors.ErrNoImage
 				}
 			})
 

--- a/services/Service.go
+++ b/services/Service.go
@@ -2,7 +2,8 @@ package services
 
 import (
 	"context"
-	"fmt"
+
+	"github.com/onego-project/onego/errors"
 
 	"github.com/onego-project/onego/requests"
 
@@ -50,12 +51,12 @@ func (s *Service) call(ctx context.Context, methodName string, args ...interface
 	resArr := result.ResultArray()
 	if !resArr[successIndex].ResultBoolean() {
 		if len(resArr) == 4 {
-			return nil, fmt.Errorf("%s, error code: %d, id of the object that caused the error %d",
-				resArr[resultIndex].ResultString(), resArr[errorCodeIndex].ResultInt(),
-				resArr[idObjectCausedErrorIndex].ResultInt())
+			return nil, &errors.OpenNebulaError{Code: int(resArr[errorCodeIndex].ResultInt()),
+				Message:  resArr[resultIndex].ResultString(),
+				ObjectID: int(resArr[idObjectCausedErrorIndex].ResultInt())}
 		}
-		return nil, fmt.Errorf("%s, code: %d", resArr[resultIndex].ResultString(),
-			resArr[errorCodeIndex].ResultInt())
+		return nil, &errors.OpenNebulaError{Code: int(resArr[errorCodeIndex].ResultInt()),
+			Message: resArr[resultIndex].ResultString(), ObjectID: errors.NoObjectID}
 	}
 
 	return resArr, nil

--- a/services/UserService_test.go
+++ b/services/UserService_test.go
@@ -3,9 +3,10 @@ package services_test
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io/ioutil"
 	"net/http"
+
+	"github.com/onego-project/onego/errors"
 
 	"github.com/dnaeon/go-vcr/cassette"
 	"github.com/dnaeon/go-vcr/recorder"
@@ -113,7 +114,7 @@ var _ = ginkgo.Describe("User Service", func() {
 		// create onego client
 		client = onego.CreateClient(endpoint, token, clientHTTP)
 		if client == nil {
-			err = fmt.Errorf("no client")
+			err = errors.ErrNoClient
 			return
 		}
 	})
@@ -198,7 +199,7 @@ var _ = ginkgo.Describe("User Service", func() {
 
 				user = resources.CreateUserWithID(idExistingUser)
 				if user == nil {
-					err = fmt.Errorf("no user to finish test")
+					err = errors.ErrNoUser
 				}
 			})
 
@@ -224,7 +225,7 @@ var _ = ginkgo.Describe("User Service", func() {
 
 				user = resources.CreateUserWithID(idNonExistingUser)
 				if user == nil {
-					err = fmt.Errorf("no user to finish test")
+					err = errors.ErrNoUser
 				}
 			})
 
@@ -259,7 +260,7 @@ var _ = ginkgo.Describe("User Service", func() {
 			ginkgo.BeforeEach(func() {
 				user = resources.CreateUserWithID(33)
 				if user == nil {
-					err = fmt.Errorf("no user to finish test")
+					err = errors.ErrNoUser
 				}
 			})
 
@@ -296,7 +297,7 @@ var _ = ginkgo.Describe("User Service", func() {
 
 				user = resources.CreateUserWithID(idNonExistingUser)
 				if user == nil {
-					err = fmt.Errorf("no user to finish test")
+					err = errors.ErrNoUser
 				}
 			})
 
@@ -335,13 +336,13 @@ var _ = ginkgo.Describe("User Service", func() {
 				ginkgo.BeforeEach(func() {
 					user = resources.CreateUserWithID(33)
 					if user == nil {
-						err = fmt.Errorf("no user to finish test")
+						err = errors.ErrNoUser
 						return
 					}
 
 					userBlueprint = blueprint.CreateUpdateUserBlueprint()
 					if userBlueprint == nil {
-						err = fmt.Errorf("no user blueprint to finish test")
+						err = errors.ErrNoUserBlueprint
 						return
 					}
 				})
@@ -404,7 +405,7 @@ var _ = ginkgo.Describe("User Service", func() {
 				ginkgo.BeforeEach(func() {
 					user = resources.CreateUserWithID(idExistingUser)
 					if user == nil {
-						err = fmt.Errorf("no user to finish test")
+						err = errors.ErrNoUser
 						return
 					}
 
@@ -445,12 +446,12 @@ var _ = ginkgo.Describe("User Service", func() {
 
 				user = resources.CreateUserWithID(idNonExistingUser)
 				if user == nil {
-					err = fmt.Errorf("no user to finish test")
+					err = errors.ErrNoUser
 				}
 
 				userBlueprint = blueprint.CreateUpdateUserBlueprint()
 				if userBlueprint == nil {
-					err = fmt.Errorf("no user blueprint to finish test")
+					err = errors.ErrNoUserBlueprint
 					return
 				}
 				userBlueprint.SetEmail("pancake@pizza.com")
@@ -470,7 +471,7 @@ var _ = ginkgo.Describe("User Service", func() {
 
 				userBlueprint = blueprint.CreateUpdateUserBlueprint()
 				if userBlueprint == nil {
-					err = fmt.Errorf("no user blueprint to finish test")
+					err = errors.ErrNoUserBlueprint
 					return
 				}
 				userBlueprint.SetEmail("pancake@pizza.com")
@@ -494,7 +495,7 @@ var _ = ginkgo.Describe("User Service", func() {
 			ginkgo.BeforeEach(func() {
 				user = resources.CreateUserWithID(33)
 				if user == nil {
-					err = fmt.Errorf("no user to finish test")
+					err = errors.ErrNoUser
 				}
 			})
 
@@ -553,7 +554,7 @@ var _ = ginkgo.Describe("User Service", func() {
 
 				user = resources.CreateUserWithID(idNonExistingUser)
 				if user == nil {
-					err = fmt.Errorf("no user to finish test")
+					err = errors.ErrNoUser
 				}
 			})
 
@@ -589,7 +590,7 @@ var _ = ginkgo.Describe("User Service", func() {
 			ginkgo.BeforeEach(func() {
 				user = resources.CreateUserWithID(33)
 				if user == nil {
-					err = fmt.Errorf("no user to finish test")
+					err = errors.ErrNoUser
 				}
 			})
 
@@ -599,7 +600,7 @@ var _ = ginkgo.Describe("User Service", func() {
 
 					group = resources.CreateGroupWithID(idExistingGroup)
 					if group == nil {
-						err = fmt.Errorf("no group to finish test")
+						err = errors.ErrNoGroup
 					}
 				})
 
@@ -626,7 +627,7 @@ var _ = ginkgo.Describe("User Service", func() {
 
 					group = resources.CreateGroupWithID(idNonExistingGroup)
 					if group == nil {
-						err = fmt.Errorf("no group to finish test")
+						err = errors.ErrNoGroup
 					}
 				})
 
@@ -658,12 +659,12 @@ var _ = ginkgo.Describe("User Service", func() {
 
 				user = resources.CreateUserWithID(idNonExistingUser)
 				if user == nil {
-					err = fmt.Errorf("no user to finish test")
+					err = errors.ErrNoUser
 				}
 
 				group = resources.CreateGroupWithID(idExistingGroup)
 				if group == nil {
-					err = fmt.Errorf("no group to finish test")
+					err = errors.ErrNoGroup
 				}
 			})
 
@@ -697,7 +698,7 @@ var _ = ginkgo.Describe("User Service", func() {
 			ginkgo.BeforeEach(func() {
 				user = resources.CreateUserWithID(idExistingUser)
 				if user == nil {
-					err = fmt.Errorf("no user to finish test")
+					err = errors.ErrNoUser
 				}
 			})
 
@@ -707,7 +708,7 @@ var _ = ginkgo.Describe("User Service", func() {
 
 					group = resources.CreateGroupWithID(idExistingNotMainGroup)
 					if group == nil {
-						err = fmt.Errorf("no group to finish test")
+						err = errors.ErrNoGroup
 					}
 				})
 
@@ -725,7 +726,7 @@ var _ = ginkgo.Describe("User Service", func() {
 
 					group = resources.CreateGroupWithID(idExistingNotMainGroup)
 					if group == nil {
-						err = fmt.Errorf("no group to finish test")
+						err = errors.ErrNoGroup
 					}
 				})
 


### PR DESCRIPTION
- Add variables with error messages - errors can be used on more places or is better comparable in case of checking an error message 
- Add structure to handle errors from OpenNebula - contains error code, message and if the error is caused by any resource, there is also ID of that resource
- Add structure to handle errors caused by XML elements