### PR TITLE
Update deps

### DIFF
--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -2,5 +2,7 @@
   "LineLength": 120,
   "Sort": ["path", "line", "column", "linter"],
   "Cyclo": 20,
-  "Enable": ["maligned", "deadcode", "errcheck", "gosec", "gochecknoinits", "goconst", "gocyclo", "gofmt", "goimports", "golint", "gotype", "gotypex", "ineffassign", "interfacer", "lll", "megacheck", "misspell", "nakedret", "structcheck", "unconvert", "unparam", "varcheck", "vet", "vetshadow"]
+  "Enable": ["maligned", "deadcode", "errcheck", "gosec", "gochecknoinits", "goconst", "gocyclo", "gofmt", "goimports",
+    "golint", "gotype", "gotypex", "ineffassign", "interfacer", "lll", "misspell", "nakedret", "staticcheck",
+    "structcheck", "unconvert", "unparam", "varcheck", "vet", "vetshadow"]
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,5 @@ before_script:
   - gometalinter --install
  
 script:
-  - diff <(echo -n) <(gofmt -l $(find -name "*.go" | grep -v /vendor))
   - gometalinter ./... --vendor --deadline 100s
   - go test ./... -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
-  - 1.9.x
   - 1.10.x
+  - 1.11.x
 
 sudo: false
 

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -8,13 +8,13 @@
   version = "v1.0.1"
 
 [[projects]]
-  branch = "master"
   name = "github.com/dnaeon/go-vcr"
   packages = [
     "cassette",
     "recorder"
   ]
-  revision = "aafff18a5cc28fa0b2f26baf6a14472cda9b54c6"
+  revision = "b3f5a17c396f1f45e232e36c6eed2577da52d22a"
+  version = "v1.0.1"
 
 [[projects]]
   branch = "master"
@@ -144,6 +144,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b95fba339fabe30ddce44cec283a958be249123668059026049f1d3ae630a2cf"
+  inputs-digest = "4b18a2aef37170b62bf979f4c4d16e84a23d3cd1b9af71f118fde701ab0ae2ef"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -30,8 +30,8 @@
   version = "1.0.1"
 
 [[constraint]]
-  branch = "master"
   name = "github.com/dnaeon/go-vcr"
+   version = "1.0.1"
 
 [[constraint]]
   name = "github.com/onego-project/xmlrpc"

--- a/services/ClusterService_test.go
+++ b/services/ClusterService_test.go
@@ -1035,7 +1035,7 @@ var _ = ginkgo.Describe("Cluster Service", func() {
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 					gomega.Expect(oneCluster).ShouldNot(gomega.BeNil())
 
-					gomega.Expect(oneCluster.Name()).To(gomega.Equal("hello"))
+					gomega.Expect(oneCluster.Name()).To(gomega.Equal(newName))
 				})
 			})
 

--- a/services/HostService_test.go
+++ b/services/HostService_test.go
@@ -435,7 +435,7 @@ var _ = ginkgo.Describe("Host Service", func() {
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 					gomega.Expect(oneHost).ShouldNot(gomega.BeNil())
 
-					gomega.Expect(oneHost.Name()).To(gomega.Equal("the_best_host"))
+					gomega.Expect(oneHost.Name()).To(gomega.Equal(newName))
 				})
 			})
 

--- a/services/VirtualNetworkService_test.go
+++ b/services/VirtualNetworkService_test.go
@@ -452,7 +452,7 @@ var _ = ginkgo.Describe("Virtual Network Service", func() {
 					gomega.Expect(err).NotTo(gomega.HaveOccurred())
 					gomega.Expect(oneVirtualNetwork).ShouldNot(gomega.BeNil())
 
-					gomega.Expect(oneVirtualNetwork.Name()).To(gomega.Equal("the_best_virtualNetwork_ever"))
+					gomega.Expect(oneVirtualNetwork.Name()).To(gomega.Equal(newName))
 				})
 			})
 


### PR DESCRIPTION
- Remove supports for megacheck and enable staticcheck
  - megacheck has been subsumed by staticcheck


- Add new version of github.com/dnaeon/go-vcr and fix tests 
  - Release 1.0.1 contains support to keep tabs on already replayed responses and replay with the next one that has not been replayed before.